### PR TITLE
Adding support for draft banner

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -70,6 +70,7 @@
 
 {{ block "main" . }}
   {{ with .Params.usabanner }}{{ partialCached "components/banner.html" . }}{{ end }}
+  {{ with .Params.draftbanner }}{{ partialCached "components/draft-banner.html" . }}{{ end }}
   {{ partialCached "components/header-basic.html" . }}
   <main class="usa-layout-docs usa-section" id="main-content">
     {{ .Content }}

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -4,6 +4,7 @@
 
 {{ define "main" }}
 {{ with .Params.usabanner }}{{ partialCached "components/banner.html" . }}{{ end }}
+{{ with .Params.draftbanner }}{{ partialCached "components/draft-banner.html" . }}{{ end }}
 {{ partialCached "components/header-extended.html" . }}
 <main id="main-content" class="usa-layout-docs">
   {{ if or (.HasShortcode "usa-section") (.HasShortcode "usa-grid-container") (.HasShortcode "usa-hero") (.HasShortcode "usa-tagline") }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -4,6 +4,7 @@
 
 {{ define "main" }}
 {{ with .Params.usabanner }}{{ partialCached "components/banner.html" . }}{{ end }}
+{{ with .Params.draftbanner }}{{ partialCached "components/draft-banner.html" . }}{{ end }}
 {{ partialCached "components/header-basic.html" . }}
 <main class="usa-layout-docs padding-top-2">
   <div class="grid-container grid-container-widescreen">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,6 +4,7 @@
 
 {{ define "main" }}
 {{ with .Params.usabanner }}{{ partialCached "components/banner.html" . }}{{ end }}
+{{ with .Params.draftbanner }}{{ partialCached "components/draft-banner.html" . }}{{ end }}
 {{ partialCached "components/header-basic.html" . }}
 <main class="usa-layout-docs padding-top-2">
   <div class="grid-container grid-container-widescreen">

--- a/layouts/partials/components/draft-banner.html
+++ b/layouts/partials/components/draft-banner.html
@@ -1,0 +1,12 @@
+<a class="usa-skipnav" href="#main-content">Skip to main content</a>
+  <section
+    class="usa-site-alert usa-site-alert--info usa-site-alert--slim"
+    aria-label="Site alert,,,,">
+    <div class="usa-alert">
+      <div class="usa-alert__body">
+        <p class="usa-alert__text">
+          <strong>DRAFT</strong> This page is currently undergoing review. Post feedback
+          to <a href="https://github.com/usnistgov/oscal-tools/issues">Github Issues</a> for this site repository.</p>
+      </div>
+    </div>
+  </section>


### PR DESCRIPTION
This pretty much just copies the code for the page banner, except using slightly different widgetry.

to do: both this and the 'official' banner (default) could be controllable in the site configuration as well as per page.