### PR TITLE
Fix hugo documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ An open-source implementation of the [The United States Web Design System ](http
 
 Implementation of the USWDS is currently incomplete, but suffecient to support a number of websites hosted at NIST. [Contributions](CONTRIBUTING.md) to improve this project are welcome.
 
-This project has been tested on HUGO version >= [0.58.3](https://github.com/gohugoio/hugo/releases/latest) and requires a `hugo-extended` build with pipe and SCSS generation support. Installation [instructions](https://gohugo.io/getting-started/installing) for common platforms are available in the Hugo [documentation](https://gohugo.io/documentation/l).
+This project has been tested on HUGO version >= [0.58.3](https://github.com/gohugoio/hugo/releases/latest) and requires a `hugo-extended` build with pipe and SCSS generation support. Installation [instructions](https://gohugo.io/getting-started/installing) for common platforms are available in the Hugo [documentation](https://gohugo.io/documentation/).


### PR DESCRIPTION
Removed accidental `l` at the end of the link so that it goes to the hugo documentation page.

From [https://gohugo.io/documentation/l](https://gohugo.io/documentation/l) to [https://gohugo.io/documentation/](https://gohugo.io/documentation/)