### PR TITLE
Allow banner config in site config

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -3,8 +3,8 @@
 {{ end }}
 
 {{ define "main" }}
-{{ with .Params.usabanner }}{{ partialCached "components/banner.html" . }}{{ end }}
-{{ with .Params.draftbanner }}{{ partialCached "components/draft-banner.html" . }}{{ end }}
+{{ with .Param "usabanner" }}{{ partialCached "components/banner.html" . }}{{ end }}
+{{ with .Param "draftbanner" }}{{ partialCached "components/draft-banner.html" . }}{{ end }}
 {{ partialCached "components/header-extended.html" . }}
 <main id="main-content" class="usa-layout-docs">
   {{ if or (.HasShortcode "usa-section") (.HasShortcode "usa-grid-container") (.HasShortcode "usa-hero") (.HasShortcode "usa-tagline") }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -3,8 +3,8 @@
 {{ end }}
 
 {{ define "main" }}
-{{ with .Params.usabanner }}{{ partialCached "components/banner.html" . }}{{ end }}
-{{ with .Params.draftbanner }}{{ partialCached "components/draft-banner.html" . }}{{ end }}
+{{ with .Param "usabanner" }}{{ partialCached "components/banner.html" . }}{{ end }}
+{{ with .Param "draftbanner" }}{{ partialCached "components/draft-banner.html" . }}{{ end }}
 {{ partialCached "components/header-basic.html" . }}
 <main class="usa-layout-docs padding-top-2">
   <div class="grid-container grid-container-widescreen">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,8 +3,8 @@
 {{ end }}
 
 {{ define "main" }}
-{{ with .Params.usabanner }}{{ partialCached "components/banner.html" . }}{{ end }}
-{{ with .Params.draftbanner }}{{ partialCached "components/draft-banner.html" . }}{{ end }}
+{{ with .Param "usabanner" }}{{ partialCached "components/banner.html" . }}{{ end }}
+{{ with .Param "draftbanner" }}{{ partialCached "components/draft-banner.html" . }}{{ end }}
 {{ partialCached "components/header-basic.html" . }}
 <main class="usa-layout-docs padding-top-2">
   <div class="grid-container grid-container-widescreen">


### PR DESCRIPTION
As-is, `usabanner` must be configured in each page's params (as does `draftbanner`) due to using `.Params.usabanner`. Using the `.Param` function instead allows looking up first at the page level and then in the site params. This will allow for enabling the banner globally and then (optionally) disabling it on select pages.