### PR TITLE
Consistently include (or exclude) tocbot code

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -135,12 +135,6 @@ $(document).ready(function(e) {
 </script>
 {{ end }}
 
-{{ $tocEnabled := true }}
-{{- with .Page.Params.toc -}}
-  {{ if isset . "enabled" }}
-    {{ $tocEnabled = .enabled }}
-  {{ end }}
-{{- end -}}
 {{- if $tocEnabled }}
 <script>
   {{ $headingselectors := "h2,h3,h4" }}


### PR DESCRIPTION
The code to initialize `$tocEnabled` is included in the `baseof` layout twice; once when the `<script>` is added to pull the library via CDN and again at the bottom of the page to actually configure and include the script. The existing implementation of the second check does not match the first; it always sets `$tocEnabled` to true unless the page sets `toc.enabled` to false (making it opt-out) whereas the first check is opt-in. This results in pages where `toc.enabled` is not specified at all logging an error that `tocbot` is undefined.

Either the same method should use used to determine whether to include tocbot-related code or the second time doing `tocbot`-related configuration should just use the already-initialized variable.

This PR removes the duplicate code and uses the already-initialized `$tocEnabled` variable, ensuring that the same behavior is alway used for both occurrences.

#### Before

| `toc.enabled` | Load from CDN | `tocbot.init` call |
|-|-|-|
| Unset | No | **Yes** |
| True | Yes | Yes |
| False | No | No |

Console error: `Uncaught ReferenceError: tocbot is not defined`

#### After

| `toc.enabled` | Load from CDN | `tocbot.init` call |
|-|-|-|
| Unset | No | **No** |
| True | Yes | Yes |
| False | No | No |

No tocbot-related error on the console