### PR TITLE
Use `absURL` instead of `baseURL` concatenation

### DIFF
--- a/assets/scss/hugo-uswds.scss
+++ b/assets/scss/hugo-uswds.scss
@@ -1,6 +1,6 @@
-$theme-font-path:   '{{ $.Site.BaseURL }}/fonts';
-$theme-image-path:  '{{ $.Site.BaseURL }}/img';
-$theme-hero-image:  '{{ $.Site.BaseURL }}/img/hero.png';
+$theme-font-path:   '{{ "fonts" | absURL }}';
+$theme-image-path:  '{{ "img" | absURL }}';
+$theme-hero-image:  '{{ "img/hero.png" | absURL }}';
 
 @import 'hugo-uswds-settings';
 @import 'hugo-uswds-theme';

--- a/layouts/shortcodes/usa-hero.html
+++ b/layouts/shortcodes/usa-hero.html
@@ -6,8 +6,7 @@
 {{ if not ($buttonURL) }}{{ errorf "missing value for param 'buttonURL': %s" .Position }}{{ end }}
 {{ $buttonText := .Get "buttonText"}}
 {{ if not ($buttonText) }}{{ errorf "missing value for param 'buttonText': %s" .Position }}{{ end }}
-{{ $baseURL := .Site.BaseURL }}
-<section class="usa-hero"{{ with $image }} style="background-image: url('{{ $baseURL }}{{ . }}')"{{ end }}>
+<section class="usa-hero"{{ with $image }} style="background-image: url('{{ . | absURL }}')"{{ end }}>
   <div class="grid-container">
     <div class="usa-hero__callout">
       <h1 class="usa-hero__heading"><span class="usa-hero__heading--alt">{{ $calloutText | markdownify }}</span>{{ with $calloutAltText }} {{ . | markdownify }}{{end}}</h1>


### PR DESCRIPTION
When concatenating with `baseURL` you can end up in strange situations with double slashes in the URL if your `baseURL` includes a trailing slash (or missing them if it doesn't). The `absURL` function handles these situations more automatically.

https://gohugo.io/functions/absurl/