### PR TITLE
Use Hugo Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,48 @@
 
 An open-source implementation of the [The United States Web Design System ](https://designsystem.digital.gov/) (USWDS) version 2.11.1 using the [Hugo](https://gohugo.io/) open-source static site generator.
 
-Implementation of the USWDS is currently incomplete, but suffecient to support a number of websites hosted at NIST. [Contributions](CONTRIBUTING.md) to improve this project are welcome.
+Implementation of the USWDS is currently incomplete, but sufficient to support a number of websites hosted at NIST. [Contributions](CONTRIBUTING.md) to improve this project are welcome.
 
 This project has been tested on HUGO version >= [0.58.3](https://github.com/gohugoio/hugo/releases/latest) and requires a `hugo-extended` build with pipe and SCSS generation support. Installation [instructions](https://gohugo.io/getting-started/installing) for common platforms are available in the Hugo [documentation](https://gohugo.io/documentation/).
+
+## Usage
+
+For details on using this theme, refer to [the documentation and demo site](https://pages.nist.gov/hugo-uswds-docs/).
+
+### Installation
+
+This template currently supports installation via Hugo Modules or as a Git Submodule.
+
+#### Using Hugo Modules
+
+For detailed instruction, refer to the [Hugo Module documentation](https://gohugo.io/hugo-modules/).
+
+1. From you project directory, initialize Hugo Modules:
+
+    ```
+    $ hugo mod init $REPOSITORY
+    ```
+
+    *NOTE: here `$REPOSITORY` should be the path to your repository (e.g. `github.com/<username>/<repository>`)*
+
+1. In your project directory, update your `config.yaml` with the following:
+
+    ```yaml
+    # import this repository as a hugo module
+    module:
+      imports:
+        - path: "github.com/usnistgov/hugo-uswds"
+    # specify that your theme is uswds
+    theme: uswds
+    ```
+
+1. The theme will be downloaded the next time you run `hugo serve`.
+
+#### Using Git Submodules
+
+From your project directory, create the submodule in the `themes/` folder:
+
+```
+$ mkdir themes
+$ git submodule add https://github.com/usnistgov/hugo-uswds.git themes/uswds
+```

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ This template currently supports installation via Hugo Modules or as a Git Submo
 
 For detailed instruction, refer to the [Hugo Module documentation](https://gohugo.io/hugo-modules/).
 
-1. From you project directory, initialize Hugo Modules:
+1. From your project directory, initialize Hugo Modules:
 
     ```
     $ hugo mod init $REPOSITORY
     ```
 
-    *NOTE: here `$REPOSITORY` should be the path to your repository (e.g. `github.com/<username>/<repository>`)*
+    *NOTE: here `$REPOSITORY` should be the path to your website repository (e.g. `github.com/<username/organization>/<repository>`)*
 
 1. In your project directory, update your `config.yaml` with the following:
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/usnistgov/hugo-uswds
+
+go 1.18


### PR DESCRIPTION
Hi all,

I'd like to propose adding support for [Hugo modules](https://gohugo.io/hugo-modules/use-modules/) for this theme.

This change has been preliminarily tested on the main OSCAL site without any issues (see [this](https://github.com/nikitawootten-nist/OSCAL/commit/23acf805d219977391e6f149534f8ac9f36abecf) commit).

## Pros

- Consumers of the theme (like OSCAL and Metaschema) won't need to submodule in this repository
- Hugo modules are versioned, making them compatible with dependabot
- Hugo modules can be overridden using Go's module syntax (see https://gohugo.io/hugo-modules/use-modules/#make-and-test-changes-in-a-module), allowing for easy testing of changes.
- This approach follows Hugo's recommendations

## Cons

This approach inevitably adds some complexity. Namely, for versioning this repository would be **forced to use tags to version releases** the same way Go libraries are typically done (`v0.0.1`...).

## Pros to the Cons

This con can also be a positive, as releases could be used to build out a build pipeline allowing you to vendor dependencies (like USWDS itself) through NPM. A GitHub action could run downloading USWDS automatically, instead of manually maintaining all the artifacts.

For an example of this, check out the Congo theme (https://github.com/jpanther/congo). 