### PR TITLE
Use fingerprint in stylesheet/script links

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -28,7 +28,7 @@
   {{ else }}
   {{ $css := $scss | toCSS $cssOpts }}
   {{ $cssFingerprint := $css | resources.Fingerprint "sha512" }}
-  <link rel="stylesheet" href="{{ $css.RelPermalink }}" integrity="{{ $cssFingerprint.Data.Integrity }}">
+  <link rel="stylesheet" href="{{ $cssFingerprint.RelPermalink }}" integrity="{{ $cssFingerprint.Data.Integrity }}">
   {{ end }}
 
   {{- with .Site.Params.custom_css -}}
@@ -38,7 +38,7 @@
     <link rel="stylesheet" href="{{ $siteCSS.RelPermalink }}">
     {{ else }}
     {{ $siteCSSFingerprint := $siteCSS | resources.Fingerprint "sha512" }}
-    <link rel="stylesheet" href="{{ $siteCSS.RelPermalink }}" integrity="{{ $siteCSSFingerprint.Data.Integrity }}">
+    <link rel="stylesheet" href="{{ $siteCSSFingerprint.RelPermalink }}" integrity="{{ $siteCSSFingerprint.Data.Integrity }}">
     {{ end }}
   {{- end -}}
   {{- end -}}
@@ -50,7 +50,7 @@
   {{- end }}
   {{ $siteCSSmin := $siteCSS | resources.Concat "/css/site.css" | minify }}
   {{ $siteCSSminSecure := $siteCSSmin | resources.Fingerprint "sha512" }}
-  <link rel="stylesheet" href="{{ $siteCSSmin.RelPermalink }}" integrity="{{ $siteCSSminSecure.Data.Integrity }}" />
+  <link rel="stylesheet" href="{{ $siteCSSminSecure.RelPermalink }}" integrity="{{ $siteCSSminSecure.Data.Integrity }}" />
   {{*/}}
 
 {{ block "head" . }}
@@ -97,14 +97,14 @@
 {{- end }}
 {{ $siteJSmin := $siteJS | resources.Concat "/js/site.js" | minify }}
 {{ $siteJSminSecure := $siteJSmin | resources.Fingerprint "sha512" }}
-<script type="text/javascript" src="{{ $siteJSmin.RelPermalink }}" integrity="{{ $siteJSminSecure.Data.Integrity }}"></script>
+<script type="text/javascript" src="{{ $siteJSminSecure.RelPermalink }}" integrity="{{ $siteJSminSecure.Data.Integrity }}"></script>
 
 {{ with .Page.Params.custom_js }}
 {{ range . -}}
   {{ $js := resources.Get . }}
   {{ $pageJSmin := $js | minify }}
   {{ $pageJSminSecure := $pageJSmin | resources.Fingerprint "sha512" }}
-  <script src="{{ $pageJSmin.RelPermalink }}" integrity="{{ $pageJSminSecure.Data.Integrity }}"></script>
+  <script src="{{ $pageJSminSecure.RelPermalink }}" integrity="{{ $pageJSminSecure.Data.Integrity }}"></script>
 {{- end }}
 {{ end }}
 


### PR DESCRIPTION
Effectively, this enables a form of cache-busting for these files as the
hash for the file is included in the URL when following this scheme.
This was already done for one of the files (on line 65, the reference to
`pageCSSminSecure`). Because SHA-512 is in use and the string isn't
trimmed, this results in fairly long file names (but again, that was
already being done in at least one place). This should make it easier
for consumers to deal with fewer caching issues (and needing to
invalidate fewer files on a CDN) after a deployment with style changes.